### PR TITLE
fix for #11

### DIFF
--- a/lib/rack/webconsole/assets.rb
+++ b/lib/rack/webconsole/assets.rb
@@ -41,7 +41,7 @@ module Rack
         # Inject the html, css and js code to the view
         response_body.gsub!('</body>', "#{code}</body>")
 
-        headers['Content-Length'] = response_body.length.to_s
+        headers['Content-Length'] = response_body.bytesize.to_s
 
         [status, headers, [response_body]]
       end

--- a/lib/rack/webconsole/repl.rb
+++ b/lib/rack/webconsole/repl.rb
@@ -90,7 +90,7 @@ module Rack
         response_body = {:result => result}.to_json
         headers = {}
         headers['Content-Type'] = 'application/json'
-        headers['Content-Length'] = response_body.length.to_s
+        headers['Content-Length'] = response_body.bytesize.to_s
         [200, headers, [response_body]]
       end
 


### PR DESCRIPTION
I wonder why we add 2 to the length of the body? This makes chrome load the page forerver and so never fire the document  onload event. Removing the +2 fixes it.
