### PR TITLE
Added command history to prompt via up/down on the keyboard

### DIFF
--- a/public/webconsole.js
+++ b/public/webconsole.js
@@ -1,4 +1,11 @@
 (function($) {
+  
+  var webconsole = {
+    history:[],
+    pointer:0,
+    query:$('#webconsole_query')
+  }
+  
   $('#rack-webconsole form').submit(function(e){
     e.preventDefault();
   });
@@ -12,25 +19,53 @@
       );
     };
 
+    // enter
     if (event.which == 13) {
-      /*$.post('/webconsole', $("#rack-webconsole form").serialize());*/
-      var query = $("#webconsole_query").val();
+      webconsole.history.push(webconsole.query.val());
+      webconsole.pointer = webconsole.history.length - 1;
       $.ajax({
         url: '/webconsole',
         type: 'POST',
         dataType: 'json',
-        data: ({query: query, token: "$TOKEN"}),
+        data: ({query: webconsole.query.val(), token: "$TOKEN"}),
         success: function (data) {
-          var q = "<div class='query'>" + escapeHTML(">> " + query) + "</div>";
+          var q = "<div class='query'>" + escapeHTML(">> " + webconsole.query.val()) + "</div>";
           var r = "<div class='result'>" + escapeHTML("=> " + data.result) + "</div>";
           $("#rack-webconsole .results").append(q + r);
           $("#rack-webconsole .results_wrapper").scrollTop(
             $("#rack-webconsole .results").height()
           );
-          $("#webconsole_query").val('');
+          webconsole.query.val('');
         }
       });
     }
+    
+    // up
+    if (event.which == 38) {
+      if (webconsole.pointer < 0) {
+        webconsole.query.val('');
+      } else {
+        if (webconsole.pointer == webconsole.history.length) {
+          webconsole.pointer = webconsole.history.length - 1;
+        }
+        webconsole.query.val(webconsole.history[webconsole.pointer]);
+        webconsole.pointer--;
+      }
+    }
+    
+    // down
+    if (event.which == 40) {
+      if (webconsole.pointer == webconsole.history.length) {
+        webconsole.query.val('');
+      } else {
+        if (webconsole.pointer < 0) {
+          webconsole.pointer = 0;
+        }
+        webconsole.query.val(webconsole.history[webconsole.pointer]);
+        webconsole.pointer++;
+      }
+    }
+    
   });
 
   $(document).ready(function() {


### PR DESCRIPTION
Hey guys check it out. I added a command history via pressing up/down on the keyboard when you're in the prompt. 

It only keeps the history per-page for now but it would be neat if it could remember your history across requests...maybe by saving to a cookie? That's phase 2. :)
