### PR TITLE
Add support for context paths

### DIFF
--- a/lib/rack/webconsole/assets.rb
+++ b/lib/rack/webconsole/assets.rb
@@ -39,7 +39,7 @@ module Rack
         Webconsole::Repl.request = Rack::Request.new(env)
 
         # Inject the html, css and js code to the view
-        response_body.gsub!('</body>', "#{code}</body>")
+        response_body.gsub!('</body>', "#{code(env)}</body>")
 
         headers['Content-Length'] = response_body.bytesize.to_s
 
@@ -53,10 +53,13 @@ module Rack
       # secure.
       #
       # @return [String] the injectable code.
-      def code
+      def code(env)
         html_code <<
           css_code <<
-          render(js_code, :TOKEN => Webconsole::Repl.token, :KEY_CODE => Webconsole.key_code)
+          render(js_code,
+                 :TOKEN => Webconsole::Repl.token,
+                 :KEY_CODE => Webconsole.key_code,
+                 :CONTEXT => env['SCRIPT_NAME'] || "")
       end
 
       private

--- a/public/webconsole.js
+++ b/public/webconsole.js
@@ -24,7 +24,7 @@
       webconsole.history.push(webconsole.query.val());
       webconsole.pointer = webconsole.history.length - 1;
       $.ajax({
-        url: '/webconsole',
+        url: '$CONTEXT/webconsole',
         type: 'POST',
         dataType: 'json',
         data: ({query: webconsole.query.val(), token: "$TOKEN"}),

--- a/spec/rack/webconsole/assets_spec.rb
+++ b/spec/rack/webconsole/assets_spec.rb
@@ -12,16 +12,18 @@ module Rack
     end
 
     describe "#code" do
-      it 'injects the token and key_code' do
+      it 'injects the token, key_code, and context path' do
         Webconsole::Repl.stubs(:token).returns('fake_generated_token')
         Webconsole.key_code = "96"
 
         @assets = Webconsole::Assets.new(nil)
-        assets_code = @assets.code
+        assets_code = @assets.code('SCRIPT_NAME' => '/hambiscuit')
 
         assets_code.must_match /fake_generated_token/
         assets_code.must_match /event\.which == 96/
+        assets_code.must_match %r{/hambiscuit/webconsole}
       end
+
     end
 
     describe "#call" do


### PR DESCRIPTION
This allows webconsole to be used in apps that aren't at the root context (/).
