### PR TITLE
autocomplete="off" on console HTML input field

### DIFF
--- a/public/webconsole.html
+++ b/public/webconsole.html
@@ -8,7 +8,7 @@
     <div class="input">
       <span class="prompt">>></span>
       <span class="input_box">
-        <input id="webconsole_query" name="webconsole_query" type="text" />
+        <input id="webconsole_query" name="webconsole_query" type="text" autocomplete="off" />
       </span>
     </div>
   </form>


### PR DESCRIPTION
## ✍️ Description

up / down arrow behavior is ruined by browser autocomplete hijacking it. this solves that issue

## 📸 Screenshots

### Before (with autocomplete on)

<img width="234" alt="Screen Shot 2022-04-20 at 11 24 33 AM" src="https://user-images.githubusercontent.com/4197823/164266389-f3a1dc25-fdf9-418a-b4d9-97f8849b53e1.png">

